### PR TITLE
Update URL to doc repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL version="3.2" maintainer="JJ Merelo <jjmerelo@GMail.com>"
 
 RUN apk update && apk upgrade && apk add graphviz  && apk add ca-certificates wget && update-ca-certificates
 
-ADD https://github.com/perl6/doc/raw/master/META6.json /tmp/
+ADD https://github.com/Raku/doc/raw/master/META6.json /tmp/
 RUN cd /tmp/ && zef update && zef install --deps-only .
 
 # Will run this


### PR DESCRIPTION
This is to trigger a rebuild of this image, following my perhaps a bit too hasty :sweat: , update in https://github.com/Raku/doc/commit/f6023dac67aadd2ce98c218601e38f45245e027c which now causes pipeline failures like this one https://github.com/Raku/doc/runs/2830207096?check_suite_focus=true

